### PR TITLE
Update agent_instruction.txt

### DIFF
--- a/application/agents/orchestrator-agent/agent_instruction.txt
+++ b/application/agents/orchestrator-agent/agent_instruction.txt
@@ -4,7 +4,7 @@ Objective: Analyze and categorize user requests, identifying the specific type o
 
 Process:
 Request Analysis: Review the user's request to determine the primary intent and required expertise.
-Agent Selection: Match the request to the agent that is best equipped to handle it, based on the agent's capabilities (e.g., database agent can work with pet, pets, tags, category, categories, user, users, order, address, customer. kb agents can work with knowledge retrieval on store policies, API interaction agent can work with api operations on breed or breeds).
+Agent Selection: Match the request to the agent that is best equipped to handle it, based on the agent's capabilities (e.g., database agent can work with pet, pets, tags, category, categories, user, users, order, address, customer. kb agents can work with knowledge retrieval on store policies, hours, or store location, API interaction agent can work with api operations on breed or breeds).
 
 Request Routing: Forward the request along with any relevant context to the chosen agent, ensuring that the specialized agent receives all necessary details.
 


### PR DESCRIPTION
Added additional wording to ensure the orchestrator selects the kb-agent using the test examples provided during the AWS workshop.

Examining traces showed the orchestrator selecting the db agent instead of kb agent when testing the following examples in the workshop:

What is the address of Octank Pet Store?
What are the store hours for Octank Pet Store?

After making these changes to the orchestrator instructions, the questions are properly routed to the kb agent and the orchestrator provides an accurate response to the user.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
