### PR TITLE
Fixing issue #4

### DIFF
--- a/application/streamlit/agents.py
+++ b/application/streamlit/agents.py
@@ -3,6 +3,13 @@ import boto3
 import json
 import logging
 import pprint
+from datetime import datetime
+
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)
 
 # Set the page configuration
 st.set_page_config(page_title="Octank Pet Store")
@@ -69,7 +76,7 @@ def invokeAgent(query, session_id, enable_trace=True, session_state=dict()):
                 return agent_answer
             elif 'trace' in event:
                 if enable_trace:
-                    logger.info(json.dumps(event['trace'], indent=2))
+                    logger.info(json.dumps(event['trace'], indent=2, cls=DateTimeEncoder))
             else:
                 raise Exception("unexpected event.", event)
     except Exception as e:


### PR DESCRIPTION
*Issue #, if available:* 3

*Description of changes:*
fixes #4 

Python's standard JSON encoder cannot automatically serialize datetime objects. The error occurs in the trace data where there's a datetime object (eventTime: datetime.datetime(2025, 3, 13, 4, 6, 12, 150315, tzinfo=tzlocal())).

To fix this issue, a custom JSON encoder that can handle datetime objects has been created.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
